### PR TITLE
Library Widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,17 @@ And then the next ten lines after that (use the `endCursor` value for `after`).
 }
 ```
 
+Dump an entire `Node` tree rooted by URN and halting at `kind`. For example,
+here we serialize all CTS URNs from their `NID` root up to (and including) the
+level of `Version` nodes, maintaining the tree structure in the final payload.
+```
+{
+  tree(urn: "urn:cts:", upTo: "version") {
+    tree
+  }
+}
+```
+
 ## Tests
 
 Invoke tests via:

--- a/data/library/tlg1271/tlg002/metadata.json
+++ b/data/library/tlg1271/tlg002/metadata.json
@@ -14,7 +14,7 @@
       "urn": "urn:cts:greekLit:tlg1271.tlg002.oaf-1:",
       "node_kind": "version",
       "version_kind": "edition",
-      "first_passage_urn": "urn:cts:greekLit:tlg1271.tlg002.oaf-1:0-1",
+      "first_passage_urn": "urn:cts:greekLit:tlg1271.tlg002.oaf-1:1",
       "citation_scheme": ["chapter", "verse"],
       "label": [
         {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django-cors-headers==3.1.1
-django-extensions==2.2.5
+django-extensions==2.2.6
 django-filter==2.2.0
 django-querycount==0.7.0
 django-treebeard==4.3

--- a/sv_mini_atlas/constants.py
+++ b/sv_mini_atlas/constants.py
@@ -69,5 +69,8 @@ INDEX = r"(\[\d+\])?"
 SUBREF = rf"(@{NODE}{INDEX})?"
 PASSAGE = rf"(((?:{NODE}\.)+)?{NODE}{SUBREF}|((?:{NODE}\.)+)?{RANGE}{SUBREF})"
 
-CTS_URN = re.compile(rf"^{NID}:{CTS_NSS}:{NS}:{WORK}:{PASSAGE}$")
+CTS_URN_NODES = ["nid", "namespace", "textgroup", "work", "version", "exemplar"]
+CTS_URN_DEPTHS = {key: idx for idx, key in enumerate(CTS_URN_NODES, 1)}
+CTS_URN_RE = re.compile(rf"^{NID}:{CTS_NSS}:{NS}:{WORK}:{PASSAGE}$")
+
 CITE_URN = None

--- a/sv_mini_atlas/library/importers.py
+++ b/sv_mini_atlas/library/importers.py
@@ -32,7 +32,7 @@ class LibraryDataResolver:
             self.versions[version["urn"]] = {"path": version_path, **version}
 
     def resolve_data_dir_path(self, data_dir_path):
-        for dirpath, dirnames, filenames in os.walk(data_dir_path):
+        for dirpath, dirnames, filenames in sorted(os.walk(data_dir_path)):
             if "metadata.json" not in filenames:
                 continue
 

--- a/sv_mini_atlas/library/importers.py
+++ b/sv_mini_atlas/library/importers.py
@@ -5,6 +5,8 @@ from collections import defaultdict
 
 from django.conf import settings
 
+from sv_mini_atlas import constants
+
 from .models import Node
 from .urn import URN
 
@@ -59,8 +61,8 @@ class CTSImporter:
     https://cite-architecture.github.io/ctsurn_spec
     """
 
-    CTS_URN_SCHEME = ["nid", "namespace", "textgroup", "work", "version"]
-    CTS_URN_SCHEME_EXEMPLAR = CTS_URN_SCHEME + ["exemplar"]
+    CTS_URN_SCHEME = constants.CTS_URN_NODES[:-1]
+    CTS_URN_SCHEME_EXEMPLAR = constants.CTS_URN_NODES
 
     def get_version_metadata(self):
         return {

--- a/sv_mini_atlas/library/models.py
+++ b/sv_mini_atlas/library/models.py
@@ -57,8 +57,13 @@ class Node(MP_Node):
             del fields["path"]
             del fields["numchild"]
 
-            fields.update({"metadata": camelize(json.loads(fields["metadata"]))})
-            newobj = {"data": camelize(fields) if to_camel else fields}
+            metadata = json.loads(fields["metadata"])
+            if to_camel:
+                fields = camelize(fields)
+                metadata = camelize(metadata)
+            fields.update({"metadata": metadata})
+
+            newobj = {"data": fields}
 
             if (not root and depth == 1) or (root and len(path) == len(root.path)):
                 tree.append(newobj)

--- a/sv_mini_atlas/library/models.py
+++ b/sv_mini_atlas/library/models.py
@@ -1,9 +1,15 @@
+import json
+
 from django.conf import settings
+from django.core import serializers
 from django.db import models
 
 # @@@ https://code.djangoproject.com/ticket/12990
 from django_extensions.db.fields.json import JSONField
+from graphene_django.utils import camelize
 from treebeard.mp_tree import MP_Node
+
+from sv_mini_atlas import constants
 
 
 class Node(MP_Node):
@@ -25,3 +31,42 @@ class Node(MP_Node):
     @property
     def name(self):
         return self.metadata.get("work_title")
+
+    @classmethod
+    def dump_tree(cls, root=None, up_to=None, to_camel=True):
+        """Dump a tree or subtree for serialization rendering all
+        fieldnames as camelCase by default.
+
+        Extension of django-treebeard.treebeard.mp_tree `dump_bulk` for
+        finer-grained control over the initial queryset and resulting value.
+        """
+        if up_to and up_to not in constants.CTS_URN_NODES:
+            raise ValueError(f"Invalid CTS node identifier for: {up_to}")
+
+        qs = cls._get_serializable_model().get_tree(parent=root)
+        if up_to:
+            depth = constants.CTS_URN_DEPTHS[up_to]
+            qs = qs.exclude(depth__gt=depth)
+
+        tree, index = [], {}
+        for pyobj in serializers.serialize("python", qs):
+            fields = pyobj["fields"]
+            path = fields["path"]
+            depth = int(len(path) / cls.steplen)
+            del fields["depth"]
+            del fields["path"]
+            del fields["numchild"]
+
+            fields.update({"metadata": camelize(json.loads(fields["metadata"]))})
+            newobj = {"data": camelize(fields) if to_camel else fields}
+
+            if (not root and depth == 1) or (root and len(path) == len(root.path)):
+                tree.append(newobj)
+            else:
+                parentpath = cls._get_basepath(path, depth - 1)
+                parentobj = index[parentpath]
+                if "children" not in parentobj:
+                    parentobj["children"] = []
+                parentobj["children"].append(newobj)
+            index[path] = newobj
+        return tree

--- a/sv_mini_atlas/library/schema.py
+++ b/sv_mini_atlas/library/schema.py
@@ -8,6 +8,7 @@ from graphene_django.filter import DjangoFilterConnectionField
 from graphene_django.utils import camelize
 
 from .models import Node as TextPart
+from .urn import URN
 from .utils import get_chunker
 
 
@@ -285,6 +286,13 @@ class VersionNode(AbstractTextPartNode):
     @classmethod
     def get_queryset(cls, queryset, info):
         return queryset.filter(kind="version").order_by("urn")
+
+    def resolve_metadata(obj, *args, **kwargs):
+        metadata = obj.metadata
+        metadata.update(
+            {"work_urn": URN(metadata["first_passage_urn"]).up_to(URN.WORK)}
+        )
+        return camelize(metadata)
 
 
 class TextPartNode(AbstractTextPartNode):

--- a/sv_mini_atlas/library/urn.py
+++ b/sv_mini_atlas/library/urn.py
@@ -61,11 +61,18 @@ class URN:
 
     @cached_property
     def node(self):
+        if self.is_range:
+            # TODO: Return entire range of Nodes?
+            raise NotImplementedError("A range URN implies multiple nodes.")
         return Node.objects.get(urn=self.absolute)
 
     @property
     def absolute(self):
         return self.urn
+
+    @property
+    def is_range(self):
+        return self.passage is not None and "-" in self.passage
 
     @property
     def has_exemplar(self):

--- a/sv_mini_atlas/library/urn.py
+++ b/sv_mini_atlas/library/urn.py
@@ -1,3 +1,8 @@
+from django.utils.functional import cached_property
+
+from .models import Node
+
+
 class URN:
     """
     Provides a subset of functionality from `MyCapytain.common.reference.URN`.
@@ -53,6 +58,10 @@ class URN:
             key = self.WORK_COMPONENT_LABELS[constant]
             parsed[key] = value
         return parsed
+
+    @cached_property
+    def node(self):
+        return Node.objects.get(urn=self.absolute)
 
     @property
     def absolute(self):

--- a/sv_mini_atlas/tests/constants.py
+++ b/sv_mini_atlas/tests/constants.py
@@ -1,3 +1,40 @@
+TREE_DATA = [
+    {
+        "data": {"urn": "urn:1:", "kind": "node"},
+        "children": [
+            {
+                "data": {"urn": "urn:11:", "kind": "node"},
+                "children": [
+                    {
+                        "data": {"urn": "urn:111:", "kind": "node"},
+                        "children": [
+                            {"data": {"urn": "urn:1111:", "kind": "node", "rank": 1}}
+                        ],
+                    },
+                    {
+                        "data": {"urn": "urn:112:", "kind": "node"},
+                        "children": [
+                            {"data": {"urn": "urn:1121:", "kind": "node", "rank": 1}}
+                        ],
+                    },
+                ],
+            },
+            {
+                "data": {"urn": "urn:12:", "kind": "node"},
+                "children": [
+                    {
+                        "data": {"urn": "urn:121:", "kind": "node"},
+                        "children": [
+                            {"data": {"urn": "urn:1211:", "kind": "node", "rank": 1}}
+                        ],
+                    },
+                ],
+            },
+        ],
+    },
+]
+
+
 # fmt: off
 PASSAGE = """
     1.1 μῆνιν ἄειδε θεὰ Πηληϊάδεω Ἀχιλῆος

--- a/sv_mini_atlas/tests/strategies.py
+++ b/sv_mini_atlas/tests/strategies.py
@@ -10,5 +10,5 @@ class URNs:
 
     @classmethod
     def cts_urns(cls, example=False):
-        strategy = strategies.from_regex(constants.CTS_URN)
+        strategy = strategies.from_regex(constants.CTS_URN_RE)
         return strategy.example() if example else strategy

--- a/sv_mini_atlas/tests/test_node.py
+++ b/sv_mini_atlas/tests/test_node.py
@@ -1,0 +1,458 @@
+from collections import OrderedDict
+
+import pytest
+
+from sv_mini_atlas.library.models import Node
+from sv_mini_atlas.tests import constants
+
+
+@pytest.mark.django_db
+def test_node_dump_tree_bypass_camel():
+    Node.load_bulk(constants.TREE_DATA)
+
+    assert Node.dump_tree(root=Node.objects.first(), to_camel=False) == [
+        {
+            "data": OrderedDict(
+                [
+                    ("idx", None),
+                    ("kind", "node"),
+                    ("urn", "urn:1:"),
+                    ("ref", None),
+                    ("rank", None),
+                    ("text_content", None),
+                    ("metadata", {}),
+                ]
+            ),
+            "children": [
+                {
+                    "data": OrderedDict(
+                        [
+                            ("idx", None),
+                            ("kind", "node"),
+                            ("urn", "urn:11:"),
+                            ("ref", None),
+                            ("rank", None),
+                            ("text_content", None),
+                            ("metadata", {}),
+                        ]
+                    ),
+                    "children": [
+                        {
+                            "data": OrderedDict(
+                                [
+                                    ("idx", None),
+                                    ("kind", "node"),
+                                    ("urn", "urn:111:"),
+                                    ("ref", None),
+                                    ("rank", None),
+                                    ("text_content", None),
+                                    ("metadata", {}),
+                                ]
+                            ),
+                            "children": [
+                                {
+                                    "data": OrderedDict(
+                                        [
+                                            ("idx", None),
+                                            ("kind", "node"),
+                                            ("urn", "urn:1111:"),
+                                            ("ref", None),
+                                            ("rank", 1),
+                                            ("text_content", None),
+                                            ("metadata", {}),
+                                        ]
+                                    )
+                                }
+                            ],
+                        },
+                        {
+                            "data": OrderedDict(
+                                [
+                                    ("idx", None),
+                                    ("kind", "node"),
+                                    ("urn", "urn:112:"),
+                                    ("ref", None),
+                                    ("rank", None),
+                                    ("text_content", None),
+                                    ("metadata", {}),
+                                ]
+                            ),
+                            "children": [
+                                {
+                                    "data": OrderedDict(
+                                        [
+                                            ("idx", None),
+                                            ("kind", "node"),
+                                            ("urn", "urn:1121:"),
+                                            ("ref", None),
+                                            ("rank", 1),
+                                            ("text_content", None),
+                                            ("metadata", {}),
+                                        ]
+                                    )
+                                }
+                            ],
+                        },
+                    ],
+                },
+                {
+                    "data": OrderedDict(
+                        [
+                            ("idx", None),
+                            ("kind", "node"),
+                            ("urn", "urn:12:"),
+                            ("ref", None),
+                            ("rank", None),
+                            ("text_content", None),
+                            ("metadata", {}),
+                        ]
+                    ),
+                    "children": [
+                        {
+                            "data": OrderedDict(
+                                [
+                                    ("idx", None),
+                                    ("kind", "node"),
+                                    ("urn", "urn:121:"),
+                                    ("ref", None),
+                                    ("rank", None),
+                                    ("text_content", None),
+                                    ("metadata", {}),
+                                ]
+                            ),
+                            "children": [
+                                {
+                                    "data": OrderedDict(
+                                        [
+                                            ("idx", None),
+                                            ("kind", "node"),
+                                            ("urn", "urn:1211:"),
+                                            ("ref", None),
+                                            ("rank", 1),
+                                            ("text_content", None),
+                                            ("metadata", {}),
+                                        ]
+                                    )
+                                }
+                            ],
+                        }
+                    ],
+                },
+            ],
+        }
+    ]
+
+
+@pytest.mark.django_db
+def test_node_dump_subtree():
+    Node.load_bulk(constants.TREE_DATA)
+
+    assert Node.dump_tree(root=Node.objects.get(urn="urn:11:")) == [
+        {
+            "data": {
+                "idx": None,
+                "kind": "node",
+                "urn": "urn:11:",
+                "ref": None,
+                "rank": None,
+                "textContent": None,
+                "metadata": {},
+            },
+            "children": [
+                {
+                    "data": {
+                        "idx": None,
+                        "kind": "node",
+                        "urn": "urn:111:",
+                        "ref": None,
+                        "rank": None,
+                        "textContent": None,
+                        "metadata": {},
+                    },
+                    "children": [
+                        {
+                            "data": {
+                                "idx": None,
+                                "kind": "node",
+                                "urn": "urn:1111:",
+                                "ref": None,
+                                "rank": 1,
+                                "textContent": None,
+                                "metadata": {},
+                            }
+                        }
+                    ],
+                },
+                {
+                    "data": {
+                        "idx": None,
+                        "kind": "node",
+                        "urn": "urn:112:",
+                        "ref": None,
+                        "rank": None,
+                        "textContent": None,
+                        "metadata": {},
+                    },
+                    "children": [
+                        {
+                            "data": {
+                                "idx": None,
+                                "kind": "node",
+                                "urn": "urn:1121:",
+                                "ref": None,
+                                "rank": 1,
+                                "textContent": None,
+                                "metadata": {},
+                            }
+                        }
+                    ],
+                },
+            ],
+        }
+    ]
+
+
+@pytest.mark.django_db
+def test_node_dump_tree_up_to():
+    Node.load_bulk(constants.TREE_DATA)
+
+    assert Node.dump_tree(root=Node.objects.first(), up_to="nid") == [
+        {
+            "data": {
+                "idx": None,
+                "kind": "node",
+                "urn": "urn:1:",
+                "ref": None,
+                "rank": None,
+                "textContent": None,
+                "metadata": {},
+            }
+        }
+    ]
+
+    assert Node.dump_tree(root=Node.objects.first(), up_to="namespace") == [
+        {
+            "data": {
+                "idx": None,
+                "kind": "node",
+                "urn": "urn:1:",
+                "ref": None,
+                "rank": None,
+                "textContent": None,
+                "metadata": {},
+            },
+            "children": [
+                {
+                    "data": {
+                        "idx": None,
+                        "kind": "node",
+                        "urn": "urn:11:",
+                        "ref": None,
+                        "rank": None,
+                        "textContent": None,
+                        "metadata": {},
+                    }
+                },
+                {
+                    "data": {
+                        "idx": None,
+                        "kind": "node",
+                        "urn": "urn:12:",
+                        "ref": None,
+                        "rank": None,
+                        "textContent": None,
+                        "metadata": {},
+                    }
+                },
+            ],
+        }
+    ]
+
+    assert Node.dump_tree(root=Node.objects.first(), up_to="textgroup") == [
+        {
+            "data": {
+                "idx": None,
+                "kind": "node",
+                "urn": "urn:1:",
+                "ref": None,
+                "rank": None,
+                "textContent": None,
+                "metadata": {},
+            },
+            "children": [
+                {
+                    "data": {
+                        "idx": None,
+                        "kind": "node",
+                        "urn": "urn:11:",
+                        "ref": None,
+                        "rank": None,
+                        "textContent": None,
+                        "metadata": {},
+                    },
+                    "children": [
+                        {
+                            "data": {
+                                "idx": None,
+                                "kind": "node",
+                                "urn": "urn:111:",
+                                "ref": None,
+                                "rank": None,
+                                "textContent": None,
+                                "metadata": {},
+                            }
+                        },
+                        {
+                            "data": {
+                                "idx": None,
+                                "kind": "node",
+                                "urn": "urn:112:",
+                                "ref": None,
+                                "rank": None,
+                                "textContent": None,
+                                "metadata": {},
+                            }
+                        },
+                    ],
+                },
+                {
+                    "data": {
+                        "idx": None,
+                        "kind": "node",
+                        "urn": "urn:12:",
+                        "ref": None,
+                        "rank": None,
+                        "textContent": None,
+                        "metadata": {},
+                    },
+                    "children": [
+                        {
+                            "data": {
+                                "idx": None,
+                                "kind": "node",
+                                "urn": "urn:121:",
+                                "ref": None,
+                                "rank": None,
+                                "textContent": None,
+                                "metadata": {},
+                            }
+                        }
+                    ],
+                },
+            ],
+        }
+    ]
+
+    assert Node.dump_tree(root=Node.objects.first(), up_to="work") == [
+        {
+            "data": {
+                "idx": None,
+                "kind": "node",
+                "urn": "urn:1:",
+                "ref": None,
+                "rank": None,
+                "textContent": None,
+                "metadata": {},
+            },
+            "children": [
+                {
+                    "data": {
+                        "idx": None,
+                        "kind": "node",
+                        "urn": "urn:11:",
+                        "ref": None,
+                        "rank": None,
+                        "textContent": None,
+                        "metadata": {},
+                    },
+                    "children": [
+                        {
+                            "data": {
+                                "idx": None,
+                                "kind": "node",
+                                "urn": "urn:111:",
+                                "ref": None,
+                                "rank": None,
+                                "textContent": None,
+                                "metadata": {},
+                            },
+                            "children": [
+                                {
+                                    "data": {
+                                        "idx": None,
+                                        "kind": "node",
+                                        "urn": "urn:1111:",
+                                        "ref": None,
+                                        "rank": 1,
+                                        "textContent": None,
+                                        "metadata": {},
+                                    }
+                                }
+                            ],
+                        },
+                        {
+                            "data": {
+                                "idx": None,
+                                "kind": "node",
+                                "urn": "urn:112:",
+                                "ref": None,
+                                "rank": None,
+                                "textContent": None,
+                                "metadata": {},
+                            },
+                            "children": [
+                                {
+                                    "data": {
+                                        "idx": None,
+                                        "kind": "node",
+                                        "urn": "urn:1121:",
+                                        "ref": None,
+                                        "rank": 1,
+                                        "textContent": None,
+                                        "metadata": {},
+                                    }
+                                }
+                            ],
+                        },
+                    ],
+                },
+                {
+                    "data": {
+                        "idx": None,
+                        "kind": "node",
+                        "urn": "urn:12:",
+                        "ref": None,
+                        "rank": None,
+                        "textContent": None,
+                        "metadata": {},
+                    },
+                    "children": [
+                        {
+                            "data": {
+                                "idx": None,
+                                "kind": "node",
+                                "urn": "urn:121:",
+                                "ref": None,
+                                "rank": None,
+                                "textContent": None,
+                                "metadata": {},
+                            },
+                            "children": [
+                                {
+                                    "data": {
+                                        "idx": None,
+                                        "kind": "node",
+                                        "urn": "urn:1211:",
+                                        "ref": None,
+                                        "rank": 1,
+                                        "textContent": None,
+                                        "metadata": {},
+                                    }
+                                }
+                            ],
+                        }
+                    ],
+                },
+            ],
+        }
+    ]

--- a/sv_mini_atlas/tests/test_urn.py
+++ b/sv_mini_atlas/tests/test_urn.py
@@ -37,6 +37,14 @@ def test_urn_invalid_component():
     assert str(excinfo.value) == "URN has no component: exemplar"
 
 
+@pytest.mark.django_db
+def test_urn_node_exception():
+    urn = URN("urn:cts:0:0.0.0:1-2")
+    with pytest.raises(NotImplementedError) as excinfo:
+        urn.node
+    assert str(excinfo.value) == "A range URN implies multiple nodes."
+
+
 @mock.patch("sv_mini_atlas.library.models.Node.objects.get")
 @pytest.mark.django_db
 def test_urn_node_cached(mock_get):


### PR DESCRIPTION
- Add a POC for a custom `dump_tree` serializer on the `Node` model that allows us to slice into the tree arbitrarily and send it to the frontend in order to visualize tree data when standing outside of a single text. As we move into dealing with more library/meta `URN` paths, generalising this seemed the right way to go. 
- Mirror the `up_to` element of the `URN` API when resolving trees.
- Add a `TreeNode` and resolver logic to the schema. As the query of this data type is not strictly tied to a Django model I've implemented this in the simplest way I could find (via `ObjectType`) and I suspect @jacobwegner will have a better idea about if we need to rationalise the approach and how to do that.
- Allow the easy lookup of a `Node` from its corresponding `URN`. Cache the lookup on the instance.

### Notes
As a result of the first point above (dealing with more library-side/meta `URN` values) I've noticed our `URN.py` and `URN.js` utilities are lagging behind a bit and neither can parse a 'partial' `URN` like `urn:cts:greekLit:`, for example. This was fine up to now as we were only really dealing with full passage `URN`s, but as we move further up the tree the implementations are starting to fail. The JavaScript version is particularly in need of some attention and it would be good if we implemented an analogous method as `up_to` in there.  I looked into fixing this up during the week but considering time demands it was larger of a job than I wanted to add to my plate and it would be nice to do it properly. I have an entire checklist of various `URN` abstraction related points that I'd like to make into a ticket, and as I mentioned to @jtauber maybe these could be done alongside the `CTS URN` widget, which still needs to be ported.

### Related PRs
- https://github.com/scaife-viewer/sv-mini/pull/1
- https://github.com/scaife-viewer/scaife-widgets/pull/15