### PR TITLE
Speed up ingestion using bulk insert / updates

### DIFF
--- a/sv_mini_atlas/library/importers.py
+++ b/sv_mini_atlas/library/importers.py
@@ -138,7 +138,7 @@ class CTSImporter:
         }
 
     def add_child_bulk(self, parent, node_data):
-        # @@@ bastardized version of `Node._inc_path`
+        # @@@ forked version of `Node._inc_path`
         # https://github.com/django-treebeard/django-treebeard/blob/master/treebeard/mp_tree.py#L1121
         child_node = Node(**node_data)
         child_node.depth = parent.depth + 1
@@ -163,6 +163,14 @@ class CTSImporter:
         return child_node
 
     def use_bulk(self, node_data):
+        """
+        `Node.save` performs multiple INSERT and UPDATE queries.
+
+        For text-part level nodes, we see a massive performance
+        benefit by batching and bulk inserting the nodes, and then
+        bulk updating any parent nodes to keep the `numchild`
+        value of nodes in sync.
+        """
         return bool(node_data.get("rank"))
 
     def generate_node(self, idx, node_data, parent_urn):

--- a/sv_mini_atlas/library/importers.py
+++ b/sv_mini_atlas/library/importers.py
@@ -189,6 +189,8 @@ class CTSImporter:
             created_count = Node.objects.filter(
                 urn__startswith=self.version_data["urn"]
             ).count()
+            # subtract the version URN
+            created_count -= 1
         else:
             created_count = Node.objects.get(
                 urn=self.version_data["urn"]

--- a/sv_mini_atlas/library/importers.py
+++ b/sv_mini_atlas/library/importers.py
@@ -69,17 +69,6 @@ class CTSImporter:
     CTS_URN_SCHEME_EXEMPLAR = constants.CTS_URN_NODES
     BULK_CREATE_PASSAGE_NODES = True
 
-    def get_version_metadata(self):
-        return {
-            # @@@ how much of the `metadata.json` do we
-            # "pass through" via GraphQL vs
-            # apply to particular node kinds in the heirarchy
-            "citation_scheme": self.citation_scheme,
-            "work_title": self.name,
-            "first_passage_urn": self.version_data["first_passage_urn"],
-            "default_toc_urn": self.version_data.get("default_toc_urn"),
-        }
-
     def __init__(self, library, version_data, nodes=dict()):
         self.library = library
         self.version_data = version_data
@@ -96,35 +85,39 @@ class CTSImporter:
         self.nodes_to_create = []
         self.node_last_child_lookup = defaultdict()
 
-    def add_child_to_parent_via_bulk_create(self, parent_node, child_node):
-        # @@@ bastardized version of `Node._inc_path`
-        # see https://github.com/django-treebeard/django-treebeard/blob/2c14a9a564cc6efc59128012aa5fc650a86a650e/treebeard/mp_tree.py#L1121
+    @staticmethod
+    def add_root(data):
+        return Node.add_root(**data)
 
-        child_node.depth = parent_node.depth + 1
+    @staticmethod
+    def add_child(parent, data):
+        return parent.add_child(**data)
 
-        last_child = self.node_last_child_lookup.get(parent_node.urn)
-        if not last_child:
-            # the node had no children, adding the first child
-            child_node.path = Node._get_path(parent_node.path, child_node.depth, 1)
-            max_length = Node._meta.get_field("path").max_length
-            if len(child_node.path) > max_length:
-                raise PathOverflow(
-                    ugettext_noop(
-                        "The new node is too deep in the tree, try"
-                        " increasing the path.max_length property"
-                        " and UPDATE your database"
-                    )
-                )
-        else:
-            # adding the new child as the last one
-            child_node.path = last_child._inc_path()
-        self.node_last_child_lookup[parent_node.urn] = child_node
-        self.nodes_to_create.append(child_node)
+    @staticmethod
+    def check_depth(path):
+        return len(path) > Node._meta.get_field("path").max_length
+
+    @staticmethod
+    def set_numchild(node):
+        # @@@ experiment with F expressions
+        # @@@ experiment with path__range queries
+        node.numchild = Node.objects.filter(
+            path__startswith=node.path, depth=node.depth + 1
+        ).count()
+
+    @staticmethod
+    def get_parent_urn(idx, branch_data):
+        return branch_data[idx - 1]["urn"] if idx else None
 
     def get_node_idx(self, kind):
         idx = self.idx_lookup[kind]
         self.idx_lookup[kind] += 1
         return idx
+
+    def get_partial_urn(self, kind, node_urn):
+        scheme = self.get_root_urn_scheme(node_urn)
+        kind_map = {kind: getattr(URN, kind.upper()) for kind in scheme}
+        return node_urn.up_to(kind_map[kind])
 
     def get_root_urn_scheme(self, node_urn):
         if node_urn.has_exemplar:
@@ -134,12 +127,54 @@ class CTSImporter:
     def get_urn_scheme(self, node_urn):
         return [*self.get_root_urn_scheme(node_urn), *self.citation_scheme]
 
-    def get_partial_urn(self, kind, node_urn):
-        scheme = self.get_root_urn_scheme(node_urn)
-        kind_map = {kind: getattr(URN, kind.upper()) for kind in scheme}
-        return node_urn.up_to(kind_map[kind])
+    def get_version_metadata(self):
+        return {
+            # @@@ how much of the `metadata.json` do we
+            # "pass through" via GraphQL vs
+            # apply to particular node kinds in the heirarchy
+            "citation_scheme": self.citation_scheme,
+            "work_title": self.name,
+            "first_passage_urn": self.version_data["first_passage_urn"],
+            "default_toc_urn": self.version_data.get("default_toc_urn"),
+        }
 
-    def destructure_node(self, node_urn, tokens):
+    def add_child_bulk(self, parent, node_data):
+        # @@@ bastardized version of `Node._inc_path`
+        # https://github.com/django-treebeard/django-treebeard/blob/master/treebeard/mp_tree.py#L1121
+        child_node = Node(**node_data)
+        child_node.depth = parent.depth + 1
+
+        last_child = self.node_last_child_lookup.get(parent.urn)
+        if not last_child:
+            # The node had no children, adding the first child.
+            child_node.path = Node._get_path(parent.path, child_node.depth, 1)
+            if self.check_depth(child_node.path):
+                raise PathOverflow(
+                    ugettext_noop(
+                        "The new node is too deep in the tree, try"
+                        " increasing the path.max_length property"
+                        " and UPDATE your database"
+                    )
+                )
+        else:
+            # Adding the new child as the last one.
+            child_node.path = last_child._inc_path()
+        self.node_last_child_lookup[parent.urn] = child_node
+        self.nodes_to_create.append(child_node)
+        return child_node
+
+    def use_bulk(self, node_data):
+        return bool(node_data.get("rank") and self.BULK_CREATE_PASSAGE_NODES)
+
+    def generate_node(self, idx, node_data, parent_urn):
+        if idx == 0:
+            return self.add_root(node_data)
+        parent = self.nodes.get(parent_urn)
+        if self.use_bulk(node_data):
+            return self.add_child_bulk(parent, node_data)
+        return self.add_child(parent, node_data)
+
+    def destructure_urn(self, node_urn, tokens):
         node_data = []
         for kind in self.get_urn_scheme(node_urn):
             data = {"kind": kind}
@@ -163,41 +198,14 @@ class CTSImporter:
     def generate_branch(self, line):
         ref, tokens = line.strip().split(maxsplit=1)
         node_urn = URN(f"{self.urn}{ref}")
-        node_data = self.destructure_node(node_urn, tokens)
-        for idx, data in enumerate(node_data):
-            node = self.nodes.get(data["urn"])
+        branch_data = self.destructure_urn(node_urn, tokens)
+        for idx, node_data in enumerate(branch_data):
+            node = self.nodes.get(node_data["urn"])
             if node is None:
-                data.update({"idx": self.get_node_idx(data["kind"])})
-                if idx == 0:
-                    node = Node.add_root(**data)
-                elif data.get("rank") and self.BULK_CREATE_PASSAGE_NODES:
-                    node = Node(**data)
-                    parent = self.nodes.get(node_data[idx - 1]["urn"])
-                    self.add_child_to_parent_via_bulk_create(parent, node)
-                else:
-                    parent = self.nodes.get(node_data[idx - 1]["urn"])
-                    node = parent.add_child(**data)
-                self.nodes[data["urn"]] = node
-
-    def set_numchild(self, node):
-        # @@@ experiment with F expressions
-        # @@@ experiment with path__range queries
-        node.numchild = Node.objects.filter(
-            path__startswith=node.path, depth=node.depth + 1
-        ).count()
-
-    def update_numchild_naively(self):
-        version = Node.objects.get(urn=self.version_data["urn"])
-        self.set_numchild(version)
-        to_update = [version]
-
-        # once `numchild` is set on version, we can get descendants
-        descendants = version.get_descendants()
-        max_depth = descendants.all().aggregate(max_depth=Max("depth"))["max_depth"]
-        for node in descendants.exclude(depth=max_depth):
-            self.set_numchild(node)
-            to_update.append(node)
-        Node.objects.bulk_update(to_update, ["numchild"], batch_size=500)
+                node_data.update({"idx": self.get_node_idx(node_data["kind"])})
+                parent_urn = self.get_parent_urn(idx, branch_data)
+                node = self.generate_node(idx, node_data, parent_urn)
+                self.nodes[node_data["urn"]] = node
 
     def update_numchild_via_subqueries(self):
         """
@@ -215,9 +223,8 @@ class CTSImporter:
         """
         # @@@ I spent too much time trying work this out with the ORM;
         # don't really see a performance improvement
-        version = Node.objects.get(urn=self.version_data["urn"])
-        descendants = Node.objects.filter(path__startswith=version.path)
-        max_depth = descendants.filter(urn__startswith=version.urn).aggregate(
+        descendants = Node.objects.filter(path__startswith=self.version_node.path)
+        max_depth = descendants.filter(urn__startswith=self.urn).aggregate(
             max_depth=Max("depth")
         )["max_depth"]
         qs = (
@@ -244,18 +251,27 @@ class CTSImporter:
 
         Node.objects.bulk_update(to_update, ["numchild"], batch_size=500)
 
+    def update_numchild_naively(self):
+        self.set_numchild(self.version_node)
+        to_update = [self.version_node]
+
+        # once `numchild` is set on version, we can get descendants
+        descendants = self.version_node.get_descendants()
+        max_depth = descendants.all().aggregate(max_depth=Max("depth"))["max_depth"]
+        for node in descendants.exclude(depth=max_depth):
+            self.set_numchild(node)
+            to_update.append(node)
+        Node.objects.bulk_update(to_update, ["numchild"], batch_size=500)
+
     def update_numchild_values(self):
         return self.update_numchild_naively()
 
     def finalize(self):
+        self.version_node = Node.objects.get(urn=self.urn.absolute)
         if self.BULK_CREATE_PASSAGE_NODES:
             Node.objects.bulk_create(self.nodes_to_create, batch_size=500)
             self.update_numchild_values()
-
-        created_count = Node.objects.get(
-            urn=self.version_data["urn"]
-        ).get_descendant_count()
-        return created_count
+        return self.version_node.get_descendant_count() + 1
 
     def apply(self):
         full_content_path = self.library.versions[self.urn.absolute]["path"]
@@ -263,8 +279,8 @@ class CTSImporter:
             for line in f:
                 self.generate_branch(line)
 
-        created_count = self.finalize()
-        print(f"{self.name}: {created_count + 1} nodes.", file=sys.stderr)
+        count = self.finalize()
+        print(f"{self.name}: {count} nodes.", file=sys.stderr)
 
 
 def resolve_library():

--- a/sv_mini_atlas/tests/test_importer.py
+++ b/sv_mini_atlas/tests/test_importer.py
@@ -13,7 +13,7 @@ def test_destructure():
     urn = URN("urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.1")
     tokens = "Some tokens"
 
-    assert CTSImporter(library, constants.VERSION_DATA).destructure_node(
+    assert CTSImporter(library, constants.VERSION_DATA).destructure_urn(
         urn, tokens
     ) == [
         {"kind": "nid", "urn": "urn:cts:"},
@@ -52,7 +52,7 @@ def test_destructure_alphanumeric():
     metadata = copy.deepcopy(constants.VERSION_METADATA)
     metadata.update({"citation_scheme": scheme})
 
-    assert CTSImporter(library, version_data).destructure_node(urn, tokens) == [
+    assert CTSImporter(library, version_data).destructure_urn(urn, tokens) == [
         {"kind": "nid", "urn": "urn:cts:"},
         {"kind": "namespace", "urn": "urn:cts:greekLit:"},
         {"kind": "textgroup", "urn": "urn:cts:greekLit:tlg0012:"},
@@ -95,146 +95,136 @@ def test_destructure_alphanumeric():
     new_callable=mock.mock_open,
     read_data=constants.PASSAGE,
 )
+@mock.patch("sv_mini_atlas.library.importers.CTSImporter.generate_node")
 @mock.patch("sv_mini_atlas.library.importers.Node")
-def test_importer(mock_node, mock_open):
+def test_importer(mock_node, mock_generate, mock_open):
     CTSImporter(library, constants.VERSION_DATA, {}).apply()
 
-    assert mock_node.mock_calls == [
-        mock.call.add_root(kind="nid", urn="urn:cts:", idx=0),
-        mock.call.add_root().add_child(
-            kind="namespace", urn="urn:cts:greekLit:", idx=0
+    assert mock_generate.mock_calls == [
+        mock.call(0, {"kind": "nid", "urn": "urn:cts:", "idx": 0}, None),
+        mock.call(
+            1, {"kind": "namespace", "urn": "urn:cts:greekLit:", "idx": 0}, "urn:cts:"
         ),
-        mock.call.add_root()
-        .add_child()
-        .add_child(kind="textgroup", urn="urn:cts:greekLit:tlg0012:", idx=0),
-        mock.call.add_root()
-        .add_child()
-        .add_child()
-        .add_child(kind="work", urn="urn:cts:greekLit:tlg0012.tlg001:", idx=0),
-        mock.call.add_root()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child(
-            kind="version",
-            urn="urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:",
-            metadata=constants.VERSION_METADATA,
-            idx=0,
+        mock.call(
+            2,
+            {"kind": "textgroup", "urn": "urn:cts:greekLit:tlg0012:", "idx": 0},
+            "urn:cts:greekLit:",
         ),
-        mock.call.add_root()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child(
-            kind="book",
-            urn="urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1",
-            ref="1",
-            rank=1,
-            idx=0,
+        mock.call(
+            3,
+            {"kind": "work", "urn": "urn:cts:greekLit:tlg0012.tlg001:", "idx": 0},
+            "urn:cts:greekLit:tlg0012:",
         ),
-        mock.call.add_root()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child(
-            kind="line",
-            urn="urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.1",
-            ref="1.1",
-            rank=2,
-            text_content="μῆνιν ἄειδε θεὰ Πηληϊάδεω Ἀχιλῆος",
-            idx=0,
+        mock.call(
+            4,
+            {
+                "kind": "version",
+                "urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:",
+                "metadata": {
+                    "citation_scheme": ["book", "line"],
+                    "work_title": "Iliad",
+                    "first_passage_urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.1-1.7",
+                    "default_toc_urn": None,
+                },
+                "idx": 0,
+            },
+            "urn:cts:greekLit:tlg0012.tlg001:",
         ),
-        mock.call.add_root()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child(
-            kind="line",
-            urn="urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.2",
-            ref="1.2",
-            rank=2,
-            text_content="οὐλομένην, ἣ μυρίʼ Ἀχαιοῖς ἄλγεʼ ἔθηκε,",
-            idx=1,
+        mock.call(
+            5,
+            {
+                "kind": "book",
+                "urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1",
+                "ref": "1",
+                "rank": 1,
+                "idx": 0,
+            },
+            "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:",
         ),
-        mock.call.add_root()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child(
-            kind="line",
-            urn="urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.3",
-            ref="1.3",
-            rank=2,
-            text_content="πολλὰς δʼ ἰφθίμους ψυχὰς Ἄϊδι προΐαψεν",
-            idx=2,
+        mock.call(
+            6,
+            {
+                "kind": "line",
+                "urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.1",
+                "ref": "1.1",
+                "rank": 2,
+                "text_content": "μῆνιν ἄειδε θεὰ Πηληϊάδεω Ἀχιλῆος",
+                "idx": 0,
+            },
+            "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1",
         ),
-        mock.call.add_root()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child(
-            kind="line",
-            urn="urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.4",
-            ref="1.4",
-            rank=2,
-            text_content="ἡρώων, αὐτοὺς δὲ ἑλώρια τεῦχε κύνεσσιν",
-            idx=3,
+        mock.call(
+            6,
+            {
+                "kind": "line",
+                "urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.2",
+                "ref": "1.2",
+                "rank": 2,
+                "text_content": "οὐλομένην, ἣ μυρίʼ Ἀχαιοῖς ἄλγεʼ ἔθηκε,",
+                "idx": 1,
+            },
+            "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1",
         ),
-        mock.call.add_root()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child(
-            kind="line",
-            urn="urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.5",
-            ref="1.5",
-            rank=2,
-            text_content="οἰωνοῖσί τε πᾶσι, Διὸς δʼ ἐτελείετο βουλή,",
-            idx=4,
+        mock.call(
+            6,
+            {
+                "kind": "line",
+                "urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.3",
+                "ref": "1.3",
+                "rank": 2,
+                "text_content": "πολλὰς δʼ ἰφθίμους ψυχὰς Ἄϊδι προΐαψεν",
+                "idx": 2,
+            },
+            "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1",
         ),
-        mock.call.add_root()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child(
-            kind="line",
-            urn="urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.6",
-            ref="1.6",
-            rank=2,
-            text_content="ἐξ οὗ δὴ τὰ πρῶτα διαστήτην ἐρίσαντε",
-            idx=5,
+        mock.call(
+            6,
+            {
+                "kind": "line",
+                "urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.4",
+                "ref": "1.4",
+                "rank": 2,
+                "text_content": "ἡρώων, αὐτοὺς δὲ ἑλώρια τεῦχε κύνεσσιν",
+                "idx": 3,
+            },
+            "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1",
         ),
-        mock.call.add_root()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child(
-            kind="line",
-            urn="urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.7",
-            ref="1.7",
-            rank=2,
-            text_content="Ἀτρεΐδης τε ἄναξ ἀνδρῶν καὶ δῖος Ἀχιλλεύς.",
-            idx=6,
+        mock.call(
+            6,
+            {
+                "kind": "line",
+                "urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.5",
+                "ref": "1.5",
+                "rank": 2,
+                "text_content": "οἰωνοῖσί τε πᾶσι, Διὸς δʼ ἐτελείετο βουλή,",
+                "idx": 4,
+            },
+            "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1",
         ),
-        mock.call.objects.get(urn="urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:"),
-        mock.call.objects.get().get_descendant_count(),
-        mock.ANY,
-        mock.ANY,
+        mock.call(
+            6,
+            {
+                "kind": "line",
+                "urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.6",
+                "ref": "1.6",
+                "rank": 2,
+                "text_content": "ἐξ οὗ δὴ τὰ πρῶτα διαστήτην ἐρίσαντε",
+                "idx": 5,
+            },
+            "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1",
+        ),
+        mock.call(
+            6,
+            {
+                "kind": "line",
+                "urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.7",
+                "ref": "1.7",
+                "rank": 2,
+                "text_content": "Ἀτρεΐδης τε ἄναξ ἀνδρῶν καὶ δῖος Ἀχιλλεύς.",
+                "idx": 6,
+            },
+            "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1",
+        ),
     ]
 
 
@@ -243,169 +233,150 @@ def test_importer(mock_node, mock_open):
     new_callable=mock.mock_open,
     read_data=constants.PASSAGE,
 )
+@mock.patch("sv_mini_atlas.library.importers.CTSImporter.generate_node")
 @mock.patch("sv_mini_atlas.library.importers.Node")
-def test_importer_exemplar(mock_node, mock_open):
+def test_importer_with_exemplar(mock_node, mock_generate, mock_open):
     version_urn = "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:"
     exemplar_urn = "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:"
-
     library_ = copy.deepcopy(library)
     exemplar_data = library_.versions.pop(version_urn)
     exemplar_data.update({"urn": exemplar_urn})
     library_.versions[exemplar_urn] = exemplar_data
+
     CTSImporter(library_, exemplar_data, {}).apply()
 
-    assert mock_node.mock_calls == [
-        mock.call.add_root(kind="nid", urn="urn:cts:", idx=0),
-        mock.call.add_root().add_child(
-            kind="namespace", urn="urn:cts:greekLit:", idx=0
+    assert mock_generate.mock_calls == [
+        mock.call(0, {"kind": "nid", "urn": "urn:cts:", "idx": 0}, None),
+        mock.call(
+            1, {"kind": "namespace", "urn": "urn:cts:greekLit:", "idx": 0}, "urn:cts:"
         ),
-        mock.call.add_root()
-        .add_child()
-        .add_child(kind="textgroup", urn="urn:cts:greekLit:tlg0012:", idx=0),
-        mock.call.add_root()
-        .add_child()
-        .add_child()
-        .add_child(kind="work", urn="urn:cts:greekLit:tlg0012.tlg001:", idx=0),
-        mock.call.add_root()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child(
-            kind="version",
-            urn="urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:",
-            metadata=constants.VERSION_METADATA,
-            idx=0,
+        mock.call(
+            2,
+            {"kind": "textgroup", "urn": "urn:cts:greekLit:tlg0012:", "idx": 0},
+            "urn:cts:greekLit:",
         ),
-        mock.call.add_root()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child(
-            kind="exemplar",
-            urn="urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:",
-            idx=0,
+        mock.call(
+            3,
+            {"kind": "work", "urn": "urn:cts:greekLit:tlg0012.tlg001:", "idx": 0},
+            "urn:cts:greekLit:tlg0012:",
         ),
-        mock.call.add_root()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child(
-            kind="book",
-            urn="urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:1",
-            ref="1",
-            rank=1,
-            idx=0,
+        mock.call(
+            4,
+            {
+                "kind": "version",
+                "urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:",
+                "metadata": {
+                    "citation_scheme": ["book", "line"],
+                    "work_title": "Iliad",
+                    "first_passage_urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:1.1-1.7",
+                    "default_toc_urn": None,
+                },
+                "idx": 0,
+            },
+            "urn:cts:greekLit:tlg0012.tlg001:",
         ),
-        mock.call.add_root()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child(
-            kind="line",
-            urn="urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:1.1",
-            ref="1.1",
-            rank=2,
-            text_content="μῆνιν ἄειδε θεὰ Πηληϊάδεω Ἀχιλῆος",
-            idx=0,
+        mock.call(
+            5,
+            {
+                "kind": "exemplar",
+                "urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:",
+                "idx": 0,
+            },
+            "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:",
         ),
-        mock.call.add_root()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child(
-            kind="line",
-            urn="urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:1.2",
-            ref="1.2",
-            rank=2,
-            text_content="οὐλομένην, ἣ μυρίʼ Ἀχαιοῖς ἄλγεʼ ἔθηκε,",
-            idx=1,
+        mock.call(
+            6,
+            {
+                "kind": "book",
+                "urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:1",
+                "ref": "1",
+                "rank": 1,
+                "idx": 0,
+            },
+            "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:",
         ),
-        mock.call.add_root()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child(
-            kind="line",
-            urn="urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:1.3",
-            ref="1.3",
-            rank=2,
-            text_content="πολλὰς δʼ ἰφθίμους ψυχὰς Ἄϊδι προΐαψεν",
-            idx=2,
+        mock.call(
+            7,
+            {
+                "kind": "line",
+                "urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:1.1",
+                "ref": "1.1",
+                "rank": 2,
+                "text_content": "μῆνιν ἄειδε θεὰ Πηληϊάδεω Ἀχιλῆος",
+                "idx": 0,
+            },
+            "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:1",
         ),
-        mock.call.add_root()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child(
-            kind="line",
-            urn="urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:1.4",
-            ref="1.4",
-            rank=2,
-            text_content="ἡρώων, αὐτοὺς δὲ ἑλώρια τεῦχε κύνεσσιν",
-            idx=3,
+        mock.call(
+            7,
+            {
+                "kind": "line",
+                "urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:1.2",
+                "ref": "1.2",
+                "rank": 2,
+                "text_content": "οὐλομένην, ἣ μυρίʼ Ἀχαιοῖς ἄλγεʼ ἔθηκε,",
+                "idx": 1,
+            },
+            "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:1",
         ),
-        mock.call.add_root()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child(
-            kind="line",
-            urn="urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:1.5",
-            ref="1.5",
-            rank=2,
-            text_content="οἰωνοῖσί τε πᾶσι, Διὸς δʼ ἐτελείετο βουλή,",
-            idx=4,
+        mock.call(
+            7,
+            {
+                "kind": "line",
+                "urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:1.3",
+                "ref": "1.3",
+                "rank": 2,
+                "text_content": "πολλὰς δʼ ἰφθίμους ψυχὰς Ἄϊδι προΐαψεν",
+                "idx": 2,
+            },
+            "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:1",
         ),
-        mock.call.add_root()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child(
-            kind="line",
-            urn="urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:1.6",
-            ref="1.6",
-            rank=2,
-            text_content="ἐξ οὗ δὴ τὰ πρῶτα διαστήτην ἐρίσαντε",
-            idx=5,
+        mock.call(
+            7,
+            {
+                "kind": "line",
+                "urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:1.4",
+                "ref": "1.4",
+                "rank": 2,
+                "text_content": "ἡρώων, αὐτοὺς δὲ ἑλώρια τεῦχε κύνεσσιν",
+                "idx": 3,
+            },
+            "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:1",
         ),
-        mock.call.add_root()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child()
-        .add_child(
-            kind="line",
-            urn="urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:1.7",
-            ref="1.7",
-            rank=2,
-            text_content="Ἀτρεΐδης τε ἄναξ ἀνδρῶν καὶ δῖος Ἀχιλλεύς.",
-            idx=6,
+        mock.call(
+            7,
+            {
+                "kind": "line",
+                "urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:1.5",
+                "ref": "1.5",
+                "rank": 2,
+                "text_content": "οἰωνοῖσί τε πᾶσι, Διὸς δʼ ἐτελείετο βουλή,",
+                "idx": 4,
+            },
+            "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:1",
         ),
-        mock.call.objects.get(urn="urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:"),
-        mock.call.objects.get().get_descendant_count(),
-        mock.ANY,
-        mock.ANY,
+        mock.call(
+            7,
+            {
+                "kind": "line",
+                "urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:1.6",
+                "ref": "1.6",
+                "rank": 2,
+                "text_content": "ἐξ οὗ δὴ τὰ πρῶτα διαστήτην ἐρίσαντε",
+                "idx": 5,
+            },
+            "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:1",
+        ),
+        mock.call(
+            7,
+            {
+                "kind": "line",
+                "urn": "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:1.7",
+                "ref": "1.7",
+                "rank": 2,
+                "text_content": "Ἀτρεΐδης τε ἄναξ ἀνδρῶν καὶ δῖος Ἀχιλλεύς.",
+                "idx": 6,
+            },
+            "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:1",
+        ),
     ]

--- a/sv_mini_atlas/tests/test_importer_fuzz.py
+++ b/sv_mini_atlas/tests/test_importer_fuzz.py
@@ -62,7 +62,7 @@ def test_destructure(urn):
     version_data = library.versions[urn.up_to(urn.VERSION)]
     version_data.update({"citation_scheme": scheme})
 
-    nodes = CTSImporter(library, version_data).destructure_node(urn, tokens)
+    nodes = CTSImporter(library, version_data).destructure_urn(urn, tokens)
 
     if urn.has_exemplar:
         assert len(nodes) - len(urn.passage_nodes) == 6

--- a/sv_mini_atlas/tests/test_importer_integration.py
+++ b/sv_mini_atlas/tests/test_importer_integration.py
@@ -42,9 +42,14 @@ def test_importer(mock_open):
     assert Node.objects.filter(kind="work").count() == 1
     assert Node.objects.filter(kind="version").count() == 1
 
+    version = Node.objects.get(urn=version_urn)
+    assert version.numchild == version.get_children().count()
+
     books = Node.objects.filter(kind="book")
     assert books.count() == 1
     assert all(book.rank == 1 for book in books)
+    book = books.first()
+    assert book.numchild == book.get_children().count()
 
     lines = Node.objects.filter(kind="line")
     assert lines.count() == 7

--- a/sv_mini_atlas/tests/test_importer_integration.py
+++ b/sv_mini_atlas/tests/test_importer_integration.py
@@ -1,0 +1,94 @@
+import copy
+from unittest import mock
+
+import pytest
+from treebeard.exceptions import PathOverflow
+
+from sv_mini_atlas.library.importers import CTSImporter, Library
+from sv_mini_atlas.library.models import Node
+from sv_mini_atlas.tests import constants
+
+
+library = Library(**constants.LIBRARY_DATA)
+
+
+@pytest.mark.django_db
+@mock.patch("sv_mini_atlas.library.importers.CTSImporter.check_depth")
+@mock.patch(
+    "sv_mini_atlas.library.importers.open",
+    new_callable=mock.mock_open,
+    read_data=constants.PASSAGE,
+)
+def test_importer_depth_exception(mock_open, mock_depth):
+    mock_depth.return_value = True
+
+    with pytest.raises(PathOverflow):
+        CTSImporter(library, constants.VERSION_DATA, {}).apply()
+
+
+@pytest.mark.django_db
+@mock.patch(
+    "sv_mini_atlas.library.importers.open",
+    new_callable=mock.mock_open,
+    read_data=constants.PASSAGE,
+)
+def test_importer(mock_open):
+    version_urn = "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:"
+
+    CTSImporter(library, constants.VERSION_DATA, {}).apply()
+
+    assert Node.objects.filter(kind="nid").count() == 1
+    assert Node.objects.filter(kind="textgroup").count() == 1
+    assert Node.objects.filter(kind="work").count() == 1
+    assert Node.objects.filter(kind="version").count() == 1
+
+    books = Node.objects.filter(kind="book")
+    assert books.count() == 1
+    assert all(book.rank == 1 for book in books)
+
+    lines = Node.objects.filter(kind="line")
+    assert lines.count() == 7
+    assert all(line.rank == 2 for line in lines)
+    assert all(line.kind == "line" for line in lines)
+    assert all(line.idx == idx for idx, line in enumerate(lines))
+    assert all(line.ref == f"{1}.{idx}" for idx, line in enumerate(lines, 1))
+    assert all(
+        line.urn == f"{version_urn}{1}.{idx}" for idx, line in enumerate(lines, 1)
+    )
+
+
+@pytest.mark.django_db
+@mock.patch(
+    "sv_mini_atlas.library.importers.open",
+    new_callable=mock.mock_open,
+    read_data=constants.PASSAGE,
+)
+def test_importer_with_exemplar(mock_open):
+    version_urn = "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2:"
+    exemplar_urn = "urn:cts:greekLit:tlg0012.tlg001.perseus-grc2.card:"
+    library_ = copy.deepcopy(library)
+    exemplar_data = library_.versions.pop(version_urn)
+    exemplar_data.update({"urn": exemplar_urn})
+    library_.versions[exemplar_urn] = exemplar_data
+
+    CTSImporter(library_, exemplar_data, {}).apply()
+
+    assert Node.objects.filter(kind="nid").count() == 1
+    assert Node.objects.filter(kind="textgroup").count() == 1
+    assert Node.objects.filter(kind="work").count() == 1
+    assert Node.objects.filter(kind="version").count() == 1
+    assert Node.objects.filter(kind="exemplar").count() == 1
+
+    books = Node.objects.filter(kind="book")
+    assert books.count() == 1
+    assert all(book.rank == 1 for book in books)
+
+    lines = Node.objects.filter(kind="line")
+    assert lines.count() == 7
+    assert all(line.rank == 2 for line in lines)
+    assert all(line.kind == "line" for line in lines)
+    assert all(line.idx == idx for idx, line in enumerate(lines))
+    assert all(line.ref == f"{1}.{idx}" for idx, line in enumerate(lines, 1))
+    assert all(
+        line.urn == f"{exemplar_urn}{1}.{idx}" for idx, line in enumerate(lines, 1)
+    )


### PR DESCRIPTION
Ingestion with `django-treebeard` is currently pretty slow, because there are _lot_ of INSERT and UPDATE statements happening.

I took a couple passes at the ingestion scripts today and have some promising early results; more to test and document, but I see the performance improvements below:

On `master`:

```
time python manage.py prepare_db
<snip>
--[Loading versions]--
Iliad: 15710 nodes.
Odyssey: 12132 nodes.
Crito: 483 nodes.
Enchiridion: 157 nodes.
The Epistle to Diognetus: 113 nodes.
The Epistle of Barnabas: 218 nodes.
The First Epistle of Clement: 469 nodes.
The Second Epistle of Clement: 139 nodes.
The Didache: 119 nodes.
The Shepherd of Hermas: 923 nodes.
Ignatius to the Ephesians: 71 nodes.
Ignatius to the Magnesians: 43 nodes.
Ignatius to the Trallians: 45 nodes.
Ignatius to the Romans: 41 nodes.
Ignatius to the Philadelphians: 37 nodes.
Ignatius to the Smyrnaeans: 44 nodes.
Ignatius to Polycarp: 32 nodes.
The Martyrdom of Polycarp: 85 nodes.
Polycarp to the Philippians: 54 nodes.
30947 total nodes on the tree.
python manage.py prepare_db  48.03s user 26.32s system 77% cpu 1:35.94 total
```

On `spike/speedy-ingestion`
```
time python manage.py prepare_db
<snip>
--[Loading versions]--
Iliad: 15710 nodes.
Odyssey: 12132 nodes.
Crito: 483 nodes.
Enchiridion: 157 nodes.
The Epistle to Diognetus: 113 nodes.
The Epistle of Barnabas: 218 nodes.
The First Epistle of Clement: 469 nodes.
The Second Epistle of Clement: 139 nodes.
The Didache: 119 nodes.
The Shepherd of Hermas: 923 nodes.
Ignatius to the Ephesians: 71 nodes.
Ignatius to the Magnesians: 43 nodes.
Ignatius to the Trallians: 45 nodes.
Ignatius to the Romans: 41 nodes.
Ignatius to the Philadelphians: 37 nodes.
Ignatius to the Smyrnaeans: 44 nodes.
Ignatius to Polycarp: 32 nodes.
The Martyrdom of Polycarp: 85 nodes.
Polycarp to the Philippians: 54 nodes.
30947 total nodes on the tree.
python manage.py prepare_db  5.04s user 0.33s system 90% cpu 5.935 total
```
_Refs ![](https://github.trello.services/images/mini-trello-icon.png) [Improve ingestion speed](https://trello.com/c/llhOXBlH)_


TODOS:
- [ ] Fix tests
- [ ] Improve internal documentation on the bulk_create flow